### PR TITLE
Make API URL configurable for statistic models

### DIFF
--- a/src/main/java/com/fijimf/deepfij/service/LinearRegressionStatisticModel.java
+++ b/src/main/java/com/fijimf/deepfij/service/LinearRegressionStatisticModel.java
@@ -7,6 +7,7 @@ import com.fijimf.deepfij.model.statistics.StatisticType;
 import com.fijimf.deepfij.model.statistics.TeamStatistic;
 import com.fijimf.deepfij.repo.TeamRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -20,13 +21,14 @@ public class LinearRegressionStatisticModel implements StatisticalModel {
     private final RestTemplate restTemplate;
     private final TeamRepository teamRepository;
     private final StatisticTypeService statisticTypeService;
-    private final String url = "http://127.0.0.1:5000/api/rankings/lse?year=%d";
+    private final String apiUrl;
 
     @Autowired
-    public LinearRegressionStatisticModel(TeamRepository teamRepository, StatisticTypeService statisticTypeService) {
+    public LinearRegressionStatisticModel(TeamRepository teamRepository, StatisticTypeService statisticTypeService, @Value("${pystats.api.url:http://127.0.0.1:5000}") String apiUrl) {
         this.teamRepository = teamRepository;
         this.statisticTypeService = statisticTypeService;
         this.restTemplate = new RestTemplate();
+        this.apiUrl = apiUrl;
     }
 
     @Override
@@ -37,7 +39,7 @@ public class LinearRegressionStatisticModel implements StatisticalModel {
     @Override
     public List<TeamStatistic> generate(Season season) {
         StatisticType type = statisticTypeService.findOrCreateStatisticType("LINEAR_REGRESSION", "LINEAR_REGRESSION", "Linear Regression", true);
-        String url = String.format("http://127.0.0.1:5000/api/rankings/lse?year=%d", season.getYear());
+        String url = String.format(apiUrl+"/api/rankings/lse?year=%d", season.getYear());
         JsonNode response = restTemplate.getForObject(url, JsonNode.class);
         List<TeamStatistic> statistics = new ArrayList<>();
         if (response != null && response.has("data")) {

--- a/src/main/java/com/fijimf/deepfij/service/LogisticRegressionStatisticModel.java
+++ b/src/main/java/com/fijimf/deepfij/service/LogisticRegressionStatisticModel.java
@@ -7,6 +7,7 @@ import com.fijimf.deepfij.model.statistics.StatisticType;
 import com.fijimf.deepfij.model.statistics.TeamStatistic;
 import com.fijimf.deepfij.repo.TeamRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -20,12 +21,14 @@ public class LogisticRegressionStatisticModel implements StatisticalModel {
     private final RestTemplate restTemplate;
     private final TeamRepository teamRepository;
     private final StatisticTypeService statisticTypeService;
+    private final String apiUrl;
 
     @Autowired
-    public LogisticRegressionStatisticModel(TeamRepository teamRepository, StatisticTypeService statisticTypeService) {
+    public LogisticRegressionStatisticModel(TeamRepository teamRepository, StatisticTypeService statisticTypeService, @Value("${pystats.api.url:http://127.0.0.1:5000}") String apiUrl) {
         this.teamRepository = teamRepository;
         this.statisticTypeService = statisticTypeService;
         this.restTemplate = new RestTemplate();
+        this.apiUrl = apiUrl;
     }
 
     @Override
@@ -36,7 +39,7 @@ public class LogisticRegressionStatisticModel implements StatisticalModel {
     @Override
     public List<TeamStatistic> generate(Season season) {
         StatisticType type = statisticTypeService.findOrCreateStatisticType("LOGISTIC_REGRESSION", "LOGISTIC_REGRESSION", "Logistic Regression", true);
-        String url = String.format("http://127.0.0.1:5000/api/rankings/logistic?year=%d", season.getYear());
+        String url = String.format(apiUrl +"/api/rankings/logistic?year=%d", season.getYear());
         JsonNode response = restTemplate.getForObject(url, JsonNode.class);
         List<TeamStatistic> statistics = new ArrayList<>();
         if (response != null && response.has("data")) {

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,9 @@
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/deepfij
+spring.datasource.username=postgres
+spring.datasource.password=p@ssw0rd
+
+pystats.api.url=http://127.0.0.1:5000
+
+logging.level.com.fijimf.deepfij.restserver=DEBUG
+logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:postgresql://db:5432/postgres?reWriteBatchedInserts=true
+spring.datasource.username=postgres
+spring.datasource.password=p@ssw0rd
+
+pystats.api.url=http://fijstats:8000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,22 +1,19 @@
 # Server Configuration
 server.port=8080
 server.servlet.context-path=/api
+
 # Database Configuration
-spring.datasource.url=jdbc:postgresql://localhost:5432/deepfij
-spring.datasource.username=postgres
-spring.datasource.password=p@ssw0rd
 spring.datasource.driver-class-name=org.postgresql.Driver
+
 # Flyway
 spring.flyway.enabled=true
+
 # JPA Configuration
 spring.jpa.hibernate.ddl-auto=none
-#spring.jpa.show-sql=true
-#spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
 # Logging Configuration
 logging.level.org.springframework=INFO
-logging.level.com.fijimf.deepfij.restserver=DEBUG
-logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG
+
 # JWT Configuration
-app.jwt.secret=yourVeryLongAndVerySecureJwtSecretKeyHerePlease
 app.jwt.expiration=86400000 


### PR DESCRIPTION
Replaced hardcoded API URLs with configurable properties via `@Value`. Added environment-specific properties files (`application-local.properties` and `application-prod.properties`) for managing API endpoints and database configurations. This enhances flexibility and environment-specific configuration setup.